### PR TITLE
request-specific events

### DIFF
--- a/example ofxSimpleHttp with request-specific listeners/testApp.cpp
+++ b/example ofxSimpleHttp with request-specific listeners/testApp.cpp
@@ -1,0 +1,143 @@
+#include "ofMain.h"
+#include "ofxSimpleHttp.h"
+
+//========================================================================
+// testApp.h
+
+class testApp : public ofBaseApp{
+
+public:
+    void setup();
+    void update();
+    void draw();
+
+    void keyPressed(int key);
+
+    ofxSimpleHttp http;
+    string theOneUrl;
+    string feedback;
+
+    // response callbacks
+    void onResponseLogStatus( ofxSimpleHttpResponse & response );
+    void onSuccessLogSize( ofxSimpleHttpResponse & response );
+    void onSuccessLogFileLocation( ofxSimpleHttpResponse & response );
+    void onFailureShowMessage( ofxSimpleHttpResponse & response );
+    void onFailureWheep( ofxSimpleHttpResponse & response );
+};
+
+
+//========================================================================
+// testApp.cpp
+
+void testApp::setup(){
+
+    ofxSimpleHttp::createSslContext();
+    theOneUrl = "https://raw.githubusercontent.com/armadillu/ofxSimpleHttp/master/ofxaddons_thumbnail.png";
+    feedback = "";
+
+    http.addCustomHttpHeader("Accept", "application/json"); //you can supply custom headers if you need to
+    http.setCopyBufferSize(16);
+    http.setSpeedLimit(100);
+}
+
+
+void testApp::update(){
+    http.update();
+}
+
+void testApp::draw(){
+    http.draw(30,30);
+    ofSetColor(255);
+
+    //clock hand to see threading in action
+    ofPushMatrix();
+    ofTranslate(ofGetWidth() - 60,60, 0);
+    ofRotate( ofGetFrameNum() * 3, 0,0,1);
+    ofSetColor(255,255,255);
+    float h = 5;
+    ofRect(-h/2,h/2, h,50);
+    ofPopMatrix();
+
+    //instructions
+    ofDrawBitmapStringHighlight("press '1', '2', '3' or '4' and see what happens\n",
+                                20,
+                                ofGetHeight() - 100);
+    ofDrawBitmapStringHighlight(feedback, 20, ofGetHeight() - 70);
+}
+
+
+void testApp::keyPressed(int key){
+
+    // fetch url and register listener for a response to this specific request
+
+    if(key=='1'){
+        ofxSimpleHttpResponse* response = http.fetchURL(theOneUrl , true/*notify when done*/);
+        if(response){
+            ofAddListener(response->responseEvent, this, &testApp::onResponseLogStatus);
+        }
+    }
+
+    // fetch url and register listener for a successfull response to this specific request
+
+    if(key=='2'){
+        ofxSimpleHttpResponse* response = http.fetchURL(theOneUrl , true/*notify when done*/);
+        if(response){
+            ofAddListener(response->successEvent, this, &testApp::onSuccessLogSize);
+        }
+    }
+
+    // like above, but do something else with the result
+
+    if(key=='3'){
+        ofxSimpleHttpResponse* response = http.fetchURLToDisk(theOneUrl , true/*notify when done*/);
+        if(response){
+            ofAddListener(response->successEvent, this, &testApp::onSuccessLogFileLocation);
+            ofAddListener(response->failureEvent, this, &testApp::onFailureShowMessage);
+
+        }
+    }
+
+    // they can't all be winners
+
+    if(key=='4'){
+        ofxSimpleHttpResponse* response = http.fetchURLToDisk("http://localhost:4321/are/you/_really_/running/this/server?#!" , true/*notify when done*/);
+        if(response){
+            ofAddListener(response->failureEvent, this, &testApp::onFailureWheep);
+        }
+    }
+}
+
+void testApp::onResponseLogStatus( ofxSimpleHttpResponse & response ){
+    feedback = "HTTP request to " + response.url + "\nresponded with status code: " + ofToString(response.status);
+}
+
+void testApp::onSuccessLogSize( ofxSimpleHttpResponse & response ){
+    feedback = response.url + " gave us\n" + ofToString(response.serverReportedSize) + " bytes of data";
+}
+
+void testApp::onSuccessLogFileLocation( ofxSimpleHttpResponse & response ){
+    feedback = response.url + " downloaded to:\n" + response.absolutePath;
+}
+
+void testApp::onFailureShowMessage( ofxSimpleHttpResponse & response ){
+    feedback = response.url + " failed.\nStatus code: " + ofToString(response.status) + "\nMessage:\n" + response.responseBody;
+}
+
+void testApp::onFailureWheep( ofxSimpleHttpResponse & response ){
+    feedback = "You requested " + response.url + ".\nThat was never gonna work, now was it?";
+
+    if(response.status == 200){
+        feedback += "\nWait, what?! This is impossible. (Literally, it is.)";
+    }
+}
+
+
+//========================================================================
+// main.cpp
+
+#include "ofAppGLFWWindow.h"
+
+int main( ){
+    ofSetupOpenGL(800,500, OF_WINDOW);
+    ofRunApp(new testApp());
+}

--- a/src/ofxSimpleHttp.cpp
+++ b/src/ofxSimpleHttp.cpp
@@ -935,6 +935,7 @@ bool ofxSimpleHttp::downloadURL(ofxSimpleHttpResponse* resp, bool sendResultThro
 
 				ofNotifyEvent(httpResponse, *resp, this);
                 ofNotifyEvent(resp->responseEvent, *resp, this); // notify request-specific callbacks
+                ofNotifyEvent(resp->status >= 200 && resp->status < 300 ? resp->successEvent : resp->failureEvent, *resp, this);
 
 			}else{
                 //we are running from a bg thread and
@@ -984,6 +985,7 @@ void ofxSimpleHttp::update(){
 		unlock();
 		ofNotifyEvent( httpResponse, r, this ); //we want to be able to notify from outside the lock
         ofNotifyEvent(r.responseEvent, r, this); // notify request-specific callbacks
+        ofNotifyEvent(r.status >= 200 && r.status < 300 ? r.successEvent : r.failureEvent, r, this);
 		//otherwise we cant start a new download from the callback (deadlock!)
 	}else{
 		unlock();

--- a/src/ofxSimpleHttp.cpp
+++ b/src/ofxSimpleHttp.cpp
@@ -498,12 +498,12 @@ ofxSimpleHttpResponse ofxSimpleHttp::fetchURLBlocking(string  url){
 	return response;
 }
 
-void ofxSimpleHttp::fetchURLToDisk(string url, string expectedSha1, bool notifyOnSuccess,
+ofxSimpleHttpResponse* ofxSimpleHttp::fetchURLToDisk(string url, string expectedSha1, bool notifyOnSuccess,
 								   string dirWhereToSave, string customField){
 
 	if (queueLenEstimation >= maxQueueLen){
 		ofLogError("ofxSimpleHttp", "fetchURL can't do that, queue is too long already (%d)!\n", queueLenEstimation );
-		return;
+		return NULL;
 	}
 
 	dirWhereToSave = ofFilePath::removeTrailingSlash(dirWhereToSave);
@@ -542,11 +542,13 @@ void ofxSimpleHttp::fetchURLToDisk(string url, string expectedSha1, bool notifyO
 			ofLogError("ofxSimpleHttp") << "ofxSimpleHttp: cant start thread!" << e.what();
 		}
 	}
+    
+    return response;
 }
 
-void ofxSimpleHttp::fetchURLToDisk(string url, bool notifyOnSuccess,
+ofxSimpleHttpResponse* ofxSimpleHttp::fetchURLToDisk(string url, bool notifyOnSuccess,
 								   string dirWhereToSave, string customField){
-	fetchURLToDisk(url, "", notifyOnSuccess, dirWhereToSave, customField);
+	return fetchURLToDisk(url, "", notifyOnSuccess, dirWhereToSave, customField);
 }
 
 

--- a/src/ofxSimpleHttp.h
+++ b/src/ofxSimpleHttp.h
@@ -137,12 +137,12 @@ class ofxSimpleHttp : public ofThread{
 		ofxSimpleHttpResponse		fetchURLBlocking(string url);
 
 		//download to Disk
-		void						fetchURLToDisk(string url,
+		ofxSimpleHttpResponse*      fetchURLToDisk(string url,
 												   bool notifyOnSuccess = false,
 												   string outputDir = ".",
 												   string customField = ""); //supply any info you need, get it back when you are notified
 
-		void						fetchURLToDisk(string url,
+		ofxSimpleHttpResponse*      fetchURLToDisk(string url,
 												   string expectedSha1,
 												   bool notifyOnSuccess = false,
 												   string outputDir = ".", string

--- a/src/ofxSimpleHttp.h
+++ b/src/ofxSimpleHttp.h
@@ -71,9 +71,14 @@ using Poco::Exception;
 using Poco::Net::HTTPClientSession;
 
 class ofxSimpleHttp;
+struct ofxSimpleHttpResponse;
+
+class ofxSimpleHttpNotifier {
+public:
+    ofEvent<ofxSimpleHttpResponse> responseEvent, successEvent, failureEvent;
+};
 
 struct ofxSimpleHttpResponse{
-
 	ofxSimpleHttp * 			who;				//who are you getting the event from?
 	bool						ok;
 	bool						notifyOnSuccess;	// user wants to be notified when download is ready
@@ -107,7 +112,8 @@ struct ofxSimpleHttpResponse{
 	ofxSimpleHttpResponse();
 	void print();
 	string toString();
-    ofEvent<ofxSimpleHttpResponse> responseEvent, successEvent, failureEvent;
+    
+    shared_ptr<ofxSimpleHttpNotifier> notifier;
 };
 
 
@@ -130,19 +136,19 @@ class ofxSimpleHttp : public ofThread{
 		// actions //////////////////////////////////////////////////////////////
 
 		//download to RAM ( download to ofxSimpleHttpResponse->responseBody)
-		ofxSimpleHttpResponse*		fetchURL(string url,
+		shared_ptr<ofxSimpleHttpNotifier> fetchURL(string url,
 											 bool notifyOnSuccess = false,
 											 string customField = ""); //supply any info you need, get it back when you are notified
 
 		ofxSimpleHttpResponse		fetchURLBlocking(string url);
 
 		//download to Disk
-		ofxSimpleHttpResponse*      fetchURLToDisk(string url,
+        shared_ptr<ofxSimpleHttpNotifier> fetchURLToDisk(string url,
 												   bool notifyOnSuccess = false,
 												   string outputDir = ".",
 												   string customField = ""); //supply any info you need, get it back when you are notified
 
-		ofxSimpleHttpResponse*      fetchURLToDisk(string url,
+		 shared_ptr<ofxSimpleHttpNotifier> fetchURLToDisk(string url,
 												   string expectedSha1,
 												   bool notifyOnSuccess = false,
 												   string outputDir = ".", string

--- a/src/ofxSimpleHttp.h
+++ b/src/ofxSimpleHttp.h
@@ -107,7 +107,7 @@ struct ofxSimpleHttpResponse{
 	ofxSimpleHttpResponse();
 	void print();
 	string toString();
-    ofEvent<ofxSimpleHttpResponse> responseEvent;
+    ofEvent<ofxSimpleHttpResponse> responseEvent, successEvent, failureEvent;
 };
 
 

--- a/src/ofxSimpleHttp.h
+++ b/src/ofxSimpleHttp.h
@@ -107,6 +107,7 @@ struct ofxSimpleHttpResponse{
 	ofxSimpleHttpResponse();
 	void print();
 	string toString();
+    ofEvent<ofxSimpleHttpResponse> responseEvent;
 };
 
 
@@ -129,7 +130,7 @@ class ofxSimpleHttp : public ofThread{
 		// actions //////////////////////////////////////////////////////////////
 
 		//download to RAM ( download to ofxSimpleHttpResponse->responseBody)
-		void						fetchURL(string url,
+		ofxSimpleHttpResponse*		fetchURL(string url,
 											 bool notifyOnSuccess = false,
 											 string customField = ""); //supply any info you need, get it back when you are notified
 

--- a/src/ofxSimpleHttp.h
+++ b/src/ofxSimpleHttp.h
@@ -71,12 +71,7 @@ using Poco::Exception;
 using Poco::Net::HTTPClientSession;
 
 class ofxSimpleHttp;
-struct ofxSimpleHttpResponse;
-
-class ofxSimpleHttpNotifier {
-public:
-    ofEvent<ofxSimpleHttpResponse> responseEvent, successEvent, failureEvent;
-};
+class ofxSimpleHttpNotifier;
 
 struct ofxSimpleHttpResponse{
 	ofxSimpleHttp * 			who;				//who are you getting the event from?
@@ -114,6 +109,26 @@ struct ofxSimpleHttpResponse{
 	string toString();
     
     shared_ptr<ofxSimpleHttpNotifier> notifier;
+};
+
+
+class ofxSimpleHttpNotifier {
+        // lets ofxSimpleHttp call the notify function
+        friend ofxSimpleHttp;
+
+    public: // lambda callback adders
+        ofxSimpleHttpNotifier* onSuccess(std::function<void (ofxSimpleHttpResponse&)> func);
+        ofxSimpleHttpNotifier* onFailure(std::function<void (ofxSimpleHttpResponse&)> func);
+        ofxSimpleHttpNotifier* onResponse(std::function<void (ofxSimpleHttpResponse&)> func);
+        
+    public: // events
+        ofEvent<ofxSimpleHttpResponse> responseEvent, successEvent, failureEvent;
+        
+    protected: // resolver method
+        void notify(ofxSimpleHttpResponse &response, bool success);
+
+    private: // attributes
+        std::vector<std::function<void (ofxSimpleHttpResponse&)>> responseFuncs, successFuncs, failureFuncs;
 };
 
 


### PR DESCRIPTION
Hey Oriol, how's it going? Hope all is well in NYC. I'm still enjoying your addons a lot, but this issue with http clients not providing request-specific callbacks puzzles me. All the http addons I find require the same workflow; register one general response handler for all requests. Is it just me or is that a very inconvenient way to process the results? (that's an honest, non-rhetoric question by the way).

Two years ago I struggled with the same thing, I think I then send a pull request with the clumsy "customField" solution, but I just realised how easy it would be to implement this based on [Node/JS Promises](https://www.promisejs.org/) for async operations.

Anyway, I prefer this approach because;

- it avoids that one big response callback with a lot of if statements to figure out what kind of response I'm processing (that is assuming I can even figure that out with the data I get).

- you can assign the listener at the same places (in the code) as the where the request is made, making the code easier to read.

One risk with the current implementation is that the caller might keep the response pointer around which becomes invalid when the response is fully processed. This could be solved by returning a shared_ptr instead, but this would require some more elaborate internal rewrites and I didn't want to go messing with your code like that. 

